### PR TITLE
fix(gpt): Don't try to read out of bounds in parseTable

### DIFF
--- a/lib/gpt.js
+++ b/lib/gpt.js
@@ -338,7 +338,7 @@ GPT.prototype = {
   parseTable( buffer, offset, end ) {
 
     offset = offset || 0
-    end = end || buffer.length
+    end = Math.min(end || buffer.length, buffer.length);
 
     var part = null
 


### PR DESCRIPTION
Hello @jhermsmeier !
This is related to https://github.com/balena-io/etcher/issues/2728
The issue happens with this image: https://www.proxmox.com/en/downloads?task=callelement&format=raw&item_id=452&element=f85c494b-2b32-4109-b8c1-083cca2b7db6&method=download&args[0]=522fc4cfb36bac995da06cf52787ad41