### PR TITLE
Rework examples

### DIFF
--- a/example/utils.js
+++ b/example/utils.js
@@ -1,0 +1,77 @@
+var fs = require( 'fs' )
+var MBR = require( 'mbr' )
+var GPT = require( '..' )
+
+function readMBR( fd, blockSize ) {
+  var buffer = Buffer.alloc( blockSize )
+  fs.readSync( fd, buffer, 0, buffer.length, 0 )
+  return MBR.parse( buffer )
+}
+
+function readPrimaryGPT( fd, blockSize, efiPart ) {
+
+  // NOTE: You'll need to know / determine the logical block size of the storage device;
+  // For the sake of brevity, we'll just go with the still most common 512 bytes
+  var gpt = new GPT({ blockSize: blockSize })
+
+  // NOTE: For protective GPTs (0xEF), the MBR's partitions
+  // attempt to span as much of the device as they can to protect
+  // against systems attempting to action on the device,
+  // so the GPT is then located at LBA 1, not the EFI partition's first LBA
+  var offset = efiPart.type == 0xEE ?
+    efiPart.firstLBA * gpt.blockSize :
+    gpt.blockSize
+
+  // The default GPT is 33 blocks in length (1 block header, 32 block table)
+  var buffer = Buffer.alloc( 33 * gpt.blockSize )
+
+  fs.readSync( fd, buffer, 0, buffer.length, offset )
+  gpt.parse( buffer )
+
+  return gpt
+
+}
+
+// function readPrimaryGPT(efiPart) {
+
+//   // NOTE: You'll need to know / determine the logical block size of the storage device;
+//   // For the sake of brevity, we'll just go with the still most common 512 bytes
+//   var gpt = new GPT({ blockSize: 512 })
+
+//   // First, we need to read & parse the GPT header, which will declare various
+//   // sizes and offsets for us to calculate where & how long the table and backup are
+//   var offset = efiPart.firstLBA * gpt.blockSize
+//   var headerBuffer = Buffer.alloc( gpt.blockSize )
+
+//   fs.readSync( fd, headerBuffer, 0, headerBuffer.length, offset )
+//   gpt.parseHeader( headerBuffer )
+
+//   // Now on to reading the actual partition table
+//   var tableBuffer = Buffer.alloc( gpt.tableSize )
+//   var tableOffset = gpt.tableOffset * gpt.blockSize
+//   fs.readSync( fd, tableBuffer, 0, tableBuffer.length, tableOffset )
+
+//   // We need to parse the first 4 partition entries & the rest separately
+//   // as the first 4 table entries always occupy one block,
+//   // with the rest following in subsequent blocks
+//   gpt.parseTable( tableBuffer, 0, gpt.blockSize )
+//   gpt.parseTable( tableBuffer, gpt.blockSize, gpt.tableSize )
+
+//   return gpt
+
+// }
+
+function readBackupGPT( fd, primaryGPT ) {
+
+  var backupGPT = new GPT({ blockSize: primaryGPT.blockSize })
+  var buffer = Buffer.alloc( 33 * primaryGPT.blockSize )
+  var offset = ( primaryGPT.backupLBA - 32 ) * primaryGPT.blockSize
+
+  fs.readSync( fd, buffer, 0, buffer.length, offset )
+  backupGPT.parseBackup( buffer )
+
+  return backupGPT
+
+}
+
+module.exports = { readMBR, readPrimaryGPT, readBackupGPT }

--- a/example/verify.js
+++ b/example/verify.js
@@ -20,8 +20,6 @@ if( !devicePath ) {
   process.exit(1)
 }
 
-console.log( '' )
-
 var blockSize = 512
 var fd = null
 
@@ -40,20 +38,21 @@ console.log( '' )
 var efiPart = mbr.getEFIPart()
 
 if( efiPart == null ) {
-  return console.error( 'No EFI partition found' )
+  console.error( 'No EFI partition found' )
+  process.exit( 1 )
 }
 
-console.log( 'EFI Parition:', inspect( efiPart ) )
+console.log( 'EFI Partition:', inspect( efiPart ) )
 console.log( '' )
 
 var primaryGPT = utils.readPrimaryGPT( fd, blockSize, efiPart )
 
-console.log( 'Primary:', inspect( primaryGPT ) )
+console.log( 'Primary GPT:', inspect( primaryGPT ) )
 console.log( '' )
 
 var backupGPT = utils.readBackupGPT( fd, primaryGPT )
 
-console.log( 'Backup:', inspect( backupGPT ) )
+console.log( 'Backup GPT:', inspect( backupGPT ) )
 console.log( '' )
 
 // Check header & table checksums for primary and backup GPT

--- a/example/verify.js
+++ b/example/verify.js
@@ -42,7 +42,15 @@ function readPrimaryGPT(efiPart) {
   // NOTE: You'll need to know / determine the logical block size of the storage device;
   // For the sake of brevity, we'll just go with the still most common 512 bytes
   var gpt = new GPT({ blockSize: blockSize })
-  var offset = efiPart.firstLBA * gpt.blockSize
+
+  // NOTE: For protective GPTs (0xEF), the MBR's partitions
+  // attempt to span as much of the device as they can to protect
+  // against systems attempting to action on the device,
+  // so the GPT is then located at LBA 1, not the EFI partition's first LBA
+  var offset = efiPart.type == 0xEE ?
+    efiPart.firstLBA * gpt.blockSize :
+    gpt.blockSize
+
   // The default GPT is 33 blocks in length (1 block header, 32 block table)
   var buffer = Buffer.alloc( 33 * gpt.blockSize )
 

--- a/example/verify.js
+++ b/example/verify.js
@@ -32,7 +32,7 @@ try {
 }
 
 function readMBR() {
-  var buffer = Buffer.alloc( 512 )
+  var buffer = Buffer.alloc( blockSize )
   fs.readSync( fd, buffer, 0, buffer.length, 0 )
   return MBR.parse( buffer )
 }
@@ -41,7 +41,7 @@ function readPrimaryGPT(efiPart) {
 
   // NOTE: You'll need to know / determine the logical block size of the storage device;
   // For the sake of brevity, we'll just go with the still most common 512 bytes
-  var gpt = new GPT({ blockSize: 512 })
+  var gpt = new GPT({ blockSize: blockSize })
   var offset = efiPart.firstLBA * gpt.blockSize
   // The default GPT is 33 blocks in length (1 block header, 32 block table)
   var buffer = Buffer.alloc( 33 * gpt.blockSize )
@@ -85,7 +85,7 @@ function readBackupGPT(primaryGPT) {
 
   var backupGPT = new GPT({ blockSize: primaryGPT.blockSize })
   var buffer = Buffer.alloc( 33 * primaryGPT.blockSize )
-  var offset = ( ( primaryGPT.backupLBA - 32 ) * blockSize )
+  var offset = ( primaryGPT.backupLBA - 32 ) * primaryGPT.blockSize
 
   fs.readSync( fd, buffer, 0, buffer.length, offset )
   backupGPT.parseBackup( buffer )

--- a/example/verify.js
+++ b/example/verify.js
@@ -47,8 +47,9 @@ function readPrimaryGPT(efiPart) {
   var buffer = Buffer.alloc( 33 * gpt.blockSize )
 
   fs.readSync( fd, buffer, 0, buffer.length, offset )
+  gpt.parse( buffer )
 
-  return GPT.parse( buffer )
+  return gpt
 
 }
 

--- a/example/verify.js
+++ b/example/verify.js
@@ -2,6 +2,7 @@ var fs = require( 'fs' )
 var MBR = require( 'mbr' )
 var GPT = require( '..' )
 var inspect = require( '../test/inspect' )
+var utils = require( './utils' )
 
 var argv = process.argv.slice( 2 )
 var devicePath = argv.shift()
@@ -31,79 +32,7 @@ try {
   process.exit( 1 )
 }
 
-function readMBR() {
-  var buffer = Buffer.alloc( blockSize )
-  fs.readSync( fd, buffer, 0, buffer.length, 0 )
-  return MBR.parse( buffer )
-}
-
-function readPrimaryGPT(efiPart) {
-
-  // NOTE: You'll need to know / determine the logical block size of the storage device;
-  // For the sake of brevity, we'll just go with the still most common 512 bytes
-  var gpt = new GPT({ blockSize: blockSize })
-
-  // NOTE: For protective GPTs (0xEF), the MBR's partitions
-  // attempt to span as much of the device as they can to protect
-  // against systems attempting to action on the device,
-  // so the GPT is then located at LBA 1, not the EFI partition's first LBA
-  var offset = efiPart.type == 0xEE ?
-    efiPart.firstLBA * gpt.blockSize :
-    gpt.blockSize
-
-  // The default GPT is 33 blocks in length (1 block header, 32 block table)
-  var buffer = Buffer.alloc( 33 * gpt.blockSize )
-
-  fs.readSync( fd, buffer, 0, buffer.length, offset )
-  gpt.parse( buffer )
-
-  return gpt
-
-}
-
-// function readPrimaryGPT(efiPart) {
-
-//   // NOTE: You'll need to know / determine the logical block size of the storage device;
-//   // For the sake of brevity, we'll just go with the still most common 512 bytes
-//   var gpt = new GPT({ blockSize: 512 })
-
-//   // First, we need to read & parse the GPT header, which will declare various
-//   // sizes and offsets for us to calculate where & how long the table and backup are
-//   var offset = efiPart.firstLBA * gpt.blockSize
-//   var headerBuffer = Buffer.alloc( gpt.blockSize )
-
-//   fs.readSync( fd, headerBuffer, 0, headerBuffer.length, offset )
-//   gpt.parseHeader( headerBuffer )
-
-//   // Now on to reading the actual partition table
-//   var tableBuffer = Buffer.alloc( gpt.tableSize )
-//   var tableOffset = gpt.tableOffset * gpt.blockSize
-//   fs.readSync( fd, tableBuffer, 0, tableBuffer.length, tableOffset )
-
-//   // We need to parse the first 4 partition entries & the rest separately
-//   // as the first 4 table entries always occupy one block,
-//   // with the rest following in subsequent blocks
-//   gpt.parseTable( tableBuffer, 0, gpt.blockSize )
-//   gpt.parseTable( tableBuffer, gpt.blockSize, gpt.tableSize )
-
-//   return gpt
-
-// }
-
-function readBackupGPT(primaryGPT) {
-
-  var backupGPT = new GPT({ blockSize: primaryGPT.blockSize })
-  var buffer = Buffer.alloc( 33 * primaryGPT.blockSize )
-  var offset = ( primaryGPT.backupLBA - 32 ) * primaryGPT.blockSize
-
-  fs.readSync( fd, buffer, 0, buffer.length, offset )
-  backupGPT.parseBackup( buffer )
-
-  return backupGPT
-
-}
-
-var mbr = readMBR()
+var mbr = utils.readMBR( fd, blockSize )
 
 console.log( 'Master Boot Record:', inspect( mbr ) )
 console.log( '' )
@@ -117,12 +46,12 @@ if( efiPart == null ) {
 console.log( 'EFI Parition:', inspect( efiPart ) )
 console.log( '' )
 
-var primaryGPT = readPrimaryGPT(efiPart)
+var primaryGPT = utils.readPrimaryGPT( fd, blockSize, efiPart )
 
 console.log( 'Primary:', inspect( primaryGPT ) )
 console.log( '' )
 
-var backupGPT = readBackupGPT(primaryGPT)
+var backupGPT = utils.readBackupGPT( fd, primaryGPT )
 
 console.log( 'Backup:', inspect( backupGPT ) )
 console.log( '' )

--- a/example/verify.js
+++ b/example/verify.js
@@ -147,3 +147,5 @@ if( !checksumsMatch ) {
   console.error( `[ERROR]: Primary & Backup GPT mismatch` )
   process.exit( 1 )
 }
+
+fs.closeSync( fd )


### PR DESCRIPTION
This set of commits are mostly cosmetics. Mostly:
- factorize code common to both examples in a file `utils.js`
- reduce cosmetics difference between `inspect.js` and `verify.js` so that the two files are easy to compare.

The one notable commit is e3c4fa176a6cb2ee2fe0de33b0cbf5cfe06ef270. This commit updates the code of `readPrimaryGPT()` according to the README which was updated lately.