### PR TITLE
Default GPT revision to the correct value

### DIFF
--- a/lib/gpt.js
+++ b/lib/gpt.js
@@ -21,8 +21,8 @@ function GPT( options ) {
 
   /** @type {String} GUID of the GUID Partition Table */
   this.guid = options.guid || GPT.GUID.ZERO
-  /** @type {Number} GPT format revision (?) */
-  this.revision = options.revision || 0
+  /** @type {Number} GPT format revision */
+  this.revision = options.revision ||  0x00010000
   /** @type {Number} Size of the GPT header in bytes */
   this.headerSize = options.headerSize || GPT.HEADER_SIZE
   /** @type {Number} GPT header's CRC32 checksum */


### PR DESCRIPTION
The [1.10 EFI specs](https://www.intel.com/content/www/us/en/architecture-and-technology/unified-extensible-firmware-interface/efi-specifications-general-technology.html) (from 2002) say "The specification revision number that this header complies to. For version 1.0 of the specification the correct value is 0x00010000."

[Wikipedia](https://en.wikipedia.org/wiki/GUID_Partition_Table#Partition_table_header_(LBA_1)) says "Revision (for GPT version 1.0 (through at least UEFI version 2.7 (May 2017)), the value is 00h 00h 01h 00h)"

Looks like this is one of those fields that got added in case the format ever changed, but in practice it never did :wink: 