### PR TITLE
Correct minimum tableSize calculation

### DIFF
--- a/lib/gpt.js
+++ b/lib/gpt.js
@@ -73,6 +73,12 @@ GPT.HEADER_SIZE = 92
 GPT.TABLE_OFFSET = 2
 
 /**
+ * Miniumum size of the partition table in bytes
+ * @type {Number}
+ */
+GPT.TABLE_MIN_SIZE = 16384
+
+/**
  * Number of partition table entries
  * @type {Number}
  */
@@ -158,8 +164,7 @@ GPT.prototype = {
    * @readOnly
    */
   get tableSize() {
-    return align( this.entrySize * 4, this.blockSize ) +
-      Math.max( align( this.entrySize * ( this.entries - 4 ), this.blockSize ), this.blockSize * 31 )
+    return Math.max( align( this.entrySize * this.entries , this.blockSize ), GPT.TABLE_MIN_SIZE )
   },
 
   /**


### PR DESCRIPTION
The EFI / GPT specs say the minimum tableSize is 16,384 bytes.

The code before this change calculated the minimum tableSize as `32 * this.blockSize`, which would be wrong with a non-512-byte sector size.